### PR TITLE
Implement: instruction sequences, let for variables, variable expressions

### DIFF
--- a/rust-semantics/execution.md
+++ b/rust-semantics/execution.md
@@ -3,12 +3,16 @@
 requires "execution/configuration.md"
 requires "execution/block.md"
 requires "execution/calls.md"
+requires "execution/let.md"
 requires "execution/stack.md"
+requires "execution/statements.md"
 
 module RUST-EXECUTION
     imports RUST-BLOCK
     imports RUST-CALLS
+    imports RUST-LET
     imports RUST-STACK
+    imports RUST-STATEMENTS
 endmodule
 
 ```

--- a/rust-semantics/execution/let.md
+++ b/rust-semantics/execution/let.md
@@ -1,0 +1,30 @@
+```k
+
+module RUST-LET
+    imports COMMON-K-CELL
+    imports RUST-CASTS
+    imports RUST-EXECUTION-CONFIGURATION
+    imports RUST-VALUE-SYNTAX
+    imports RUST-SHARED-SYNTAX
+
+    // Not all cases are implemented
+    rule
+        <k>
+            let Variable:Identifier : T:Type = V:Value ; => .K
+            ...
+        </k>
+        <next-value-id> NextId:Int => NextId +Int 1 </next-value-id>
+        <locals> Locals:Map => Locals[Variable <- NextId] </locals>
+        <values> Values:Map => Values[NextId <- implicitCast(V, T)] </values>
+    rule
+        <k>
+            let Variable:Identifier = V:Value ; => .K
+            ...
+        </k>
+        <next-value-id> NextId:Int => NextId +Int 1 </next-value-id>
+        <locals> Locals:Map => Locals[Variable <- NextId] </locals>
+        <values> Values:Map => Values[NextId <- V] </values>
+    requires notBool mayBeDefaultTypedInt(V)
+endmodule
+
+```

--- a/rust-semantics/execution/statements.md
+++ b/rust-semantics/execution/statements.md
@@ -1,0 +1,11 @@
+```k
+
+module RUST-STATEMENTS
+    imports RUST-SHARED-SYNTAX
+
+    rule Nes:NonEmptyStatements E:Expression => Nes ~> E
+    rule S:Statement Ss:NonEmptyStatements => S ~> Ss
+    rule .NonEmptyStatements => .K
+endmodule
+
+```

--- a/rust-semantics/expression.md
+++ b/rust-semantics/expression.md
@@ -1,9 +1,11 @@
 ```k
 requires "expression/casts.md"
 requires "expression/literals.md"
+requires "expression/variables.md"
 
 module RUST-EXPRESSION
     imports private RUST-CASTS
     imports private RUST-EXPRESSION-LITERALS
+    imports private RUST-EXPRESSION-VARIABLES
 endmodule
 ```

--- a/rust-semantics/expression/casts.md
+++ b/rust-semantics/expression/casts.md
@@ -42,12 +42,6 @@ module RUST-CASTS
     // We don't need a value for the unit type
     rule implicitCastTo(( )) => .K
 
-    // Rewrites
-
-    rule V:Value ~> castTo(T:Type) => cast(V, T)
-    // We don't need a value for the unit type
-    rule castTo(( )) => .K
-
 endmodule
 
 ```

--- a/rust-semantics/expression/casts.md
+++ b/rust-semantics/expression/casts.md
@@ -42,6 +42,12 @@ module RUST-CASTS
     // We don't need a value for the unit type
     rule implicitCastTo(( )) => .K
 
+    // Rewrites
+
+    rule V:Value ~> castTo(T:Type) => cast(V, T)
+    // We don't need a value for the unit type
+    rule castTo(( )) => .K
+
 endmodule
 
 ```

--- a/rust-semantics/expression/variables.md
+++ b/rust-semantics/expression/variables.md
@@ -1,0 +1,18 @@
+```k
+
+module RUST-EXPRESSION-VARIABLES
+    imports COMMON-K-CELL
+    imports RUST-EXECUTION-CONFIGURATION
+    imports RUST-VALUE-SYNTAX
+    imports RUST-SHARED-SYNTAX
+
+    rule
+        <k>
+            Variable:Identifier :: .PathExprSegments => V
+            ...
+        </k>
+        <locals> Variable |-> VarId:Int ... </locals>
+        <values> VarId |-> V:Value ... </values>
+endmodule
+
+```

--- a/rust-semantics/representation.md
+++ b/rust-semantics/representation.md
@@ -1,6 +1,7 @@
 ```k
 
 module RUST-VALUE-SYNTAX
+    imports BOOL
     imports LIST  // for filling the second argument of `error`.
     imports MAP
     imports MINT
@@ -28,6 +29,10 @@ module RUST-VALUE-SYNTAX
     syntax KResult ::= Value
 
     syntax ValueOrError ::= Value | SemanticsError
+
+    syntax Bool ::= mayBeDefaultTypedInt(Value)  [function, total]
+    rule mayBeDefaultTypedInt(_V) => false  [owise]
+    rule mayBeDefaultTypedInt(u128(_)) => true
 endmodule
 
 module RUST-REPRESENTATION

--- a/rust-semantics/rust-common-syntax.md
+++ b/rust-semantics/rust-common-syntax.md
@@ -737,9 +737,9 @@ https://doc.rust-lang.org/reference/items/extern-crates.html
 
 ```k
 
-  syntax LetStatement ::= OuterAttributes "let" PatternNoTopAlt MaybeColonType MaybeEqualsExpressionMaybeElseBlockExpression ";"
+  syntax LetStatement ::= OuterAttributes "let" PatternNoTopAlt MaybeColonType ";"
+                        | OuterAttributes "let" PatternNoTopAlt MaybeColonType "=" Expression MaybeElseBlockExpression ";"  [strict(4)]
   syntax MaybeColonType ::= "" | ":" Type
-  syntax MaybeEqualsExpressionMaybeElseBlockExpression ::= "" | "=" Expression MaybeElseBlockExpression
   // TODO: Not implemented properly to remove ambiguities
   syntax MaybeElseBlockExpression ::= "" // | "else" BlockExpression
 

--- a/rust-semantics/targets/preprocessing/rust.md
+++ b/rust-semantics/targets/preprocessing/rust.md
@@ -3,7 +3,8 @@
 requires "configuration.md"
 requires "../../preprocessing.md"
 requires "../../representation.md"
-requires "../../expression.md"
+requires "../../expression/casts.md"
+requires "../../expression/literals.md"
 requires "../../rust-common-syntax.md"
 
 module RUST-SYNTAX
@@ -11,7 +12,7 @@ module RUST-SYNTAX
 endmodule
 
 module RUST
-    imports private RUST-EXPRESSION
+    imports private RUST-EXPRESSION-LITERALS
     imports private RUST-PREPROCESSING
     imports private RUST-RUNNING-CONFIGURATION
 endmodule

--- a/tests/execution/let-final-expression.1.run
+++ b/tests/execution/let-final-expression.1.run
@@ -1,0 +1,4 @@
+new LetFinal;
+call LetFinal.let_final;
+return_value;
+check_eq 100_u64

--- a/tests/execution/let-final-expression.rs
+++ b/tests/execution/let-final-expression.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+#[allow(unused_imports)]
+use multiversx_sc::imports::*;
+
+#[multiversx_sc::contract]
+pub trait LetFinal {
+    #[init]
+    fn init(&self) {
+    }
+
+    #[upgrade]
+    fn upgrade(&self) {}
+
+    fn let_final(&self) -> u64 {
+        let x = 100_u64;
+        x
+    }
+}


### PR DESCRIPTION
Closes #15 
Partly implements #16 (which still needs to work with tuples)
Partly implements #27 (constants not implemented yet)

Needs #64 