### PR TITLE
Adding the ERC20 contract and UKM file

### DIFF
--- a/tests/ukm-contracts/erc_20_token.rs
+++ b/tests/ukm-contracts/erc_20_token.rs
@@ -61,7 +61,7 @@ pub trait Erc20Token {
     fn init(&self, name: &ManagedBuffer, symbol: &ManagedBuffer, init_supply: u64) {
         self.s_name().set_if_empty(name);
         self.s_symbol().set_if_empty(symbol);
-        self._mint(::ukm::Caller(), , init_supply);
+        self._mint(::ukm::Caller(), init_supply);
     }
 
     #[upgrade]
@@ -89,7 +89,7 @@ pub trait Erc20Token {
 
     #[endpoint(transfer)]
     fn transfer(&self, to: u64, value: u64) -> bool {
-        let owner = ::ukm::Caller(), ;
+        let owner = ::ukm::Caller();
         self._transfer(&owner, to, &value);
         true
     }
@@ -101,14 +101,14 @@ pub trait Erc20Token {
 
     #[endpoint(approve)]
     fn approve(&self, spender: u64, value: u64) -> bool {
-        let owner = ::ukm::Caller(), ;
+        let owner = ::ukm::Caller();
         self._approve(&owner, spender, value, true);
         true
     }
 
     #[endpoint(transferFrom)]
     fn transfer_from(&self, from: u64, to: u64, value: u64) -> bool {
-        let spender = ::ukm::Caller(), ;
+        let spender = ::ukm::Caller();
         self._spend_allowance(from, &spender, value);
         self._transfer(from, to, value);
         true

--- a/tests/ukm-contracts/erc_20_token.rs
+++ b/tests/ukm-contracts/erc_20_token.rs
@@ -16,9 +16,9 @@ use ukm::*;
 /* ----------------------------------------------------------------------------
 
 TODOs:
-    - Integers are all u64. Implement u256 and modify appropriately;
+    - Integers are all u64 at the moment. Implement u256 and modify appropriately;
     - Reuse the implementation of ManagedBuffer for strings, and the annotations for
-      the contract trait identification, as well as views, storage mapers, update, and
+      the contract trait identification, as well as views, storage mappers, update, and
       inits;
     - Support some sort of struct for implementing MessageResult within the UKM module.
       We also have to figure out the contents of MessageResult.

--- a/tests/ukm-contracts/erc_20_token.rs
+++ b/tests/ukm-contracts/erc_20_token.rs
@@ -1,0 +1,160 @@
+// This contract is a translation of
+// https://github.com/Pi-Squared-Inc/pi2-examples/blob/b63d0a78922874a486be8a0395a627425fb5a052/solidity/src/tokens/SomeToken.sol
+//
+// The main change is that the contract does not issue specific error objects
+// (e.g. ERC20InsufficientBalance), it just calls `require!` with various
+// (string) explanations.
+//
+// Also, the `totalSupply` endpoint is declared implicitely as a view for
+// `s_total_supply`.
+
+#![no_std]
+
+#[allow(unused_imports)]
+use ukm::*;
+
+/* ----------------------------------------------------------------------------
+
+TODOs:
+    - Integers are all u64. Implement u256 and modify appropriately;
+    - Reuse the implementation of ManagedBuffer for strings, and the annotations for
+      the contract trait identification, as well as views, storage mapers, update, and
+      inits;
+    - Support some sort of struct for implementing MessageResult within the UKM module.
+      We also have to figure out the contents of MessageResult.
+  
+Observations:
+    - ManagedAddress was replaced by an integer to fit the behaviors of UKM;
+    
+---------------------------------------------------------------------------- */
+
+#[ukm::contract]
+pub trait Erc20Token {
+    #[view(totalSupply)]
+    #[storage_mapper("total_supply")]
+    fn s_total_supply(&self) -> SingleValueMapper<u64>;
+
+    #[view(getName)]
+    #[storage_mapper("name")]
+    fn s_name(&self) -> SingleValueMapper<ManagedBuffer>;
+
+    #[view(getSymbol)]
+    #[storage_mapper("symbol")]
+    fn s_symbol(&self) -> SingleValueMapper<ManagedBuffer>;
+
+    #[view(getBalances)]
+    #[storage_mapper("balances")]
+    fn s_balances(&self, address: u64) -> SingleValueMapper<u64>;
+
+    #[view(getAllowances)]
+    #[storage_mapper("balances")]
+    fn s_allowances(&self, account: u64, spender: u64) -> SingleValueMapper<u64>;
+
+    #[event("Transfer")]
+    fn transfer_event(&self, #[indexed] from: u64, #[indexed] to: u64, value: u64);
+    
+    #[event("Approval")]
+    fn approval_event(&self, #[indexed] owner: u64, #[indexed] spender: u64, value: u64);
+
+
+    #[init]
+    fn init(&self, name: &ManagedBuffer, symbol: &ManagedBuffer, init_supply: u64) {
+        self.s_name().set_if_empty(name);
+        self.s_symbol().set_if_empty(symbol);
+        self._mint(::ukm::Caller(), , init_supply);
+    }
+
+    #[upgrade]
+    fn upgrade(&self) {}
+
+    #[view(decimals)]
+    fn decimals(&self) -> u8 {
+        18
+    }
+
+    #[view(name)]
+    fn name(&self) -> ManagedBuffer {
+        self.s_name().get()
+    }
+
+    #[view(symbol)]
+    fn symbol(&self) -> ManagedBuffer {
+        self.s_symbol().get()
+    }
+
+    #[view(balanceOf)]
+    fn balance_of(&self, account: u64) -> u64 {
+        self.s_balances(account).get()
+    }
+
+    #[endpoint(transfer)]
+    fn transfer(&self, to: u64, value: u64) -> bool {
+        let owner = ::ukm::Caller(), ;
+        self._transfer(&owner, to, &value);
+        true
+    }
+
+    #[view(allowance)]
+    fn allowance(&self, owner: u64, spender: u64) -> u64 {
+        self.s_allowances(owner, spender).get()
+    }
+
+    #[endpoint(approve)]
+    fn approve(&self, spender: u64, value: u64) -> bool {
+        let owner = ::ukm::Caller(), ;
+        self._approve(&owner, spender, value, true);
+        true
+    }
+
+    #[endpoint(transferFrom)]
+    fn transfer_from(&self, from: u64, to: u64, value: u64) -> bool {
+        let spender = ::ukm::Caller(), ;
+        self._spend_allowance(from, &spender, value);
+        self._transfer(from, to, value);
+        true
+    }
+
+    fn _transfer(&self, from: u64, to: u64, value: u64) {
+        require!(!from.is_zero(), "Invalid sender");
+        require!(!to.is_zero(), "Invalid receiver");
+        self._update(from, to, value);
+        self.transfer_event(from, to, value);
+    }
+
+    fn _update(&self, from: u64, to: u64, value: u64) {
+        if from.is_zero() {
+            self.s_total_supply().set(self.s_total_supply().get() + value);
+        } else {
+            let from_balance = self.s_balances(from).get();
+            require!(value <= &from_balance, "Insufficient balance");
+            self.s_balances(from).set(self.s_balances(from).get() - value);
+        };
+
+        if to.is_zero() {
+            self.s_total_supply().set(self.s_total_supply().get() - value);
+        } else {
+            self.s_balances(to).set(self.s_balances(to).get() + value);
+        }
+    }
+
+    fn _mint(&self, account: u64, value: u64) {
+        require!(!account.is_zero(), "Zero address");
+        self._update(0_u64, account, value);
+    }
+
+    fn _approve(&self, owner: u64, spender: u64, value: u64, emit_event: bool) {
+        require!(!owner.is_zero(), "Invalid approver");
+        require!(!spender.is_zero(), "Invalid spender");
+        self.s_allowances(owner, spender).set(value);
+        if emit_event {
+            self.approval_event(owner, spender, value);
+        }
+    }
+
+    fn _spend_allowance(&self, owner: u64, spender: u64, value: u64) {
+        let current_allowance = self.allowance(owner, spender);
+        require!(value <= &current_allowance, "Insuficient allowance");
+        self._approve(owner, spender, &(current_allowance - value), false);
+    }
+
+}

--- a/tests/ukm-contracts/ukm.rs
+++ b/tests/ukm-contracts/ukm.rs
@@ -1,0 +1,78 @@
+#![no_std]
+
+// TODO: Support structs and figure out the content of MessageResult
+struct MessageResult { }
+
+pub const EVMC_REJECTED: u64 = 0_u64;
+pub const EVMC_INTERNAL_ERROR: u64 = 1_u64;
+pub const EVMC_SUCCESS: u64 = 2_u64;
+pub const EVMC_REVERT: u64 = 3_u64;
+pub const EVMC_FAILURE: u64 = 4_u64;
+pub const EVMC_INVALID_INSTRUCTION: u64 = 5_u64;
+pub const EVMC_UNDEFINED_INSTRUCTION: u64 = 6_u64;
+pub const EVMC_OUT_OF_GAS: u64 = 7_u64;
+pub const EVMC_BAD_JUMP_DESTINATION: u64 = 8_u64;
+pub const EVMC_STACK_OVERFLOW: u64 = 9_u64;
+pub const EVMC_STACK_UNDERFLOW: u64 = 10_u64;
+pub const EVMC_CALL_DEPTH_EXCEEDED: u64 = 11_u64;
+pub const EVMC_INVALID_MEMORY_ACCESS: u64 = 12_u64;
+pub const EVMC_STATIC_MODE_VIOLATION: u64 = 13_u64;
+pub const EVMC_PRECOMPILE_FAILURE: u64 = 14_u64;
+pub const EVMC_NONCE_EXCEEDED: u64 = 15_u64;
+
+extern {    
+    // block parameters
+    fn sample_method(&self) -> u64;
+    fn GasLimit(&self) -> u64;
+    fn BaseFee(&self) -> u64;
+    fn Coinbase(&self) -> u64;
+    fn BlockTimestamp(&self) -> u64;
+    fn BlockNumber(&self) -> u64;
+    fn BlockDifficulty(&self) -> u64;
+    fn PrevRandao(&self) -> u64;
+    fn BlockHash(&self, index: u64) -> u64;
+
+    // transaction parameters
+    fn GasPrice(&self) -> u64;
+    fn Origin(&self) -> u64;
+    
+    // message parameters
+    fn Address(&self) -> u64;
+    fn Caller(&self) -> u64;
+    fn CallValue(&self) -> u64;
+    fn CallData(&self) -> Bytes;
+
+    // chain parameters
+    fn ChainId(&self) -> u64;
+    
+    // account getters
+    fn GetAccountBalance(&self, acct: u64) -> u64;
+    fn GetAccountCode(&self, acct: u64) -> u64;
+    fn GetAccountStorage(&self, key: u64) -> u64;
+    fn GetAccountOrigStorage(&self, key: u64) -> u64;
+    fn GetAccountTransientStorage(&self, key: u64) -> u64;
+    fn IsAccountEmpty(&self, acct: u64) -> bool;
+
+    // to be removed in final version
+    fn AccessedStorage(&self, key: u64) -> bool;
+    fn AccessedAccount(&self, acct: u64) -> bool;
+
+    fn Transfer(&self, to: u64, value: u64) -> bool;
+    fn SelfDestruct(&self, to: u64);
+    fn SetAccountStorage(&self, key: u64, value: u64);
+    fn SetAccountTransientStorage(&self, key: u64, value: u64);
+
+    fn Log0(data: Bytes);
+    fn Log1(topic0: u64, data: Bytes);
+    fn Log2(topic0: u64, topic1: u64, data: Bytes);
+    fn Log3(topic0: u64, topic1: u64, topic2: u64, data: Bytes);
+    fn Log4(topic0: u64, topic1: u64, topic2: u64, topic3: u64, data: Bytes); 
+    
+    fn MessageResult(gas: u64, data: Bytes, status: u64, target: u64) -> MessageResult;
+    fn Create(value: u64, data: Bytes, gas: u64) -> MessageResult;
+    fn Create2(value: u64, data: Bytes, salt: Bytes, gas: u64) -> MessageResult;
+    fn Call(gas: u64, to: u64, value: u64, data: Bytes) -> MessageResult;
+    fn CallCode(gas: u64, to: u64, value: u64, data: Bytes) -> MessageResult;
+    fn DelegateCall(gas: u64, to: u64, data: Bytes) -> MessageResult;
+    fn StaticCall(gas: u64, to: u64, data: Bytes) -> MessageResult;
+}


### PR DESCRIPTION
Adding the first version of the UKM-compliant ERC20 contract. The current version needs a set of features to work, as elaborated on by the TODOs in the contract:

```
TODOs:
    - Integers are all u64 at the moment. Implement u256 and modify appropriately;
    - Reuse the implementation of ManagedBuffer for strings, and the annotations for
      the contract trait identification, as well as views, storage mappers, update, and
      inits;
    - Support some sort of struct for implementing MessageResult within the UKM module.
      We also have to figure out the contents of MessageResult.
  
Observations:
    - ManagedAddress was replaced by an integer to fit the behaviors of UKM;
```

These files are not associated with tests currently, and should be once the necessary infrastructure for running it is implemented.
