### PR TITLE
Remove end-of-line spaces

### DIFF
--- a/rust-semantics/rust-common-syntax.md
+++ b/rust-semantics/rust-common-syntax.md
@@ -199,7 +199,7 @@ https://doc.rust-lang.org/reference/items/extern-crates.html
   syntax StructStruct ::= "struct" Identifier MaybeGenericParams MaybeWhereClause "{" MaybeStructFields "}"
   syntax MaybeStructFields ::= "" | StructFields | StructFields ","
   syntax StructFields ::= NeList{StructField, ","}
-  syntax StructField ::= OuterAttributes MaybeVisibility Identifier ":" Type //TODO: Outerfields and visibility for 
+  syntax StructField ::= OuterAttributes MaybeVisibility Identifier ":" Type //TODO: Outerfields and visibility for
                                                                              //struct fields is not yet supported.
 
 ```
@@ -545,21 +545,21 @@ https://doc.rust-lang.org/reference/items/extern-crates.html
 
 ```k
 
-  syntax StructExpression ::= StructExprStruct 
-                            | StructExprTuple 
+  syntax StructExpression ::= StructExprStruct
+                            | StructExprTuple
                             | StructExprUnit
   syntax StructExprStruct ::= TypePath "{" MaybeStructExprFieldsOrStructBase "}" //TODO: Not implemented properly
                                                                                  //Should use PathInExpression instead of
-                                                                                 //TypePath. 
+                                                                                 //TypePath.
   syntax MaybeStructExprFieldsOrStructBase ::= "" | StructExprFields | StructBases //TODO: Not implemented properly
                                                                         //StructBases should be
                                                                         //singular. and its correct
-                                                                        //value is:  StructExprField (, StructExprField)* (, StructBase | ,?)  
-  syntax StructExprFields ::= NeList{StructExprField, ","} 
+                                                                        //value is:  StructExprField (, StructExprField)* (, StructBase | ,?)
+  syntax StructExprFields ::= NeList{StructExprField, ","}
   syntax StructBases ::= NeList{StructBase, ","}
   syntax StructExprField ::= Identifier ":" Expression //TODO: Not implemented properly. Needs outer attributes.
 
-  syntax StructBase ::= Expression //TODO: Not implemented properly. Actual value should be '".." Expression' 
+  syntax StructBase ::= Expression //TODO: Not implemented properly. Actual value should be '".." Expression'
   syntax StructExprUnit ::= "TODO: not needed yet, not implementing"
   syntax StructExprTuple ::= "TODO: not needed yet, not implementing"
 
@@ -724,12 +724,12 @@ https://doc.rust-lang.org/reference/items/extern-crates.html
 
 ```k
 
-  syntax IfExpression ::= "if" ExpressionExceptStructExpression BlockExpression  MaybeIfElseExpression [strict(1)] 
+  syntax IfExpression ::= "if" ExpressionExceptStructExpression BlockExpression  MaybeIfElseExpression [strict(1)]
 
-  syntax MaybeIfElseExpression ::= "" 
+  syntax MaybeIfElseExpression ::= ""
                                  | "else" IfElseExpression
-  syntax IfElseExpression ::= BlockExpression 
-                            | IfExpression  
+  syntax IfElseExpression ::= BlockExpression
+                            | IfExpression
                             | IfLetExpression
   // TODO: Not implemented properly
   syntax ExpressionExceptStructExpression ::= Expression
@@ -815,7 +815,7 @@ https://doc.rust-lang.org/reference/items/extern-crates.html
 
 ```k
 
-  syntax RangePattern ::= Expression ".." Expression 
+  syntax RangePattern ::= Expression ".." Expression
 
 ```
 

--- a/tests/ulm-with-contract/erc_20_token.1.run
+++ b/tests/ulm-with-contract/erc_20_token.1.run
@@ -25,10 +25,10 @@ list_mock GetAccountStorageHook ( 1154948450467236006739439905978168116697077396
 list_mock GetAccountStorageHook ( 17171626450567201640701347902808840427582371480602455275836469707331258301780 ) ulmIntResult(300, u256);
 
 push "uint256";
-hold_list_values_from_test_stack; 
+hold_list_values_from_test_stack;
 push 10000_u256;
-hold_list_values_from_test_stack; 
-encode_constructor_data; 
+hold_list_values_from_test_stack;
+encode_constructor_data;
 
 
 return_value;
@@ -52,12 +52,12 @@ check_eq 0_u32;
 
 
 push "balanceOf";
-hold_string_from_test_stack; 
-push "address"; 
-hold_list_values_from_test_stack; 
+hold_string_from_test_stack;
+push "address";
+hold_list_values_from_test_stack;
 push 1010101_u160;
-hold_list_values_from_test_stack; 
-encode_call_data; 
+hold_list_values_from_test_stack;
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -77,13 +77,13 @@ check_eq 10000_u256;
 
 push "transfer";
 hold_string_from_test_stack;
-push "address"; 
-push "uint256"; 
-hold_list_values_from_test_stack; 
+push "address";
+push "uint256";
+hold_list_values_from_test_stack;
 push 2020202_u160;
 push 100_u256;
-hold_list_values_from_test_stack; 
-encode_call_data; 
+hold_list_values_from_test_stack;
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -107,10 +107,10 @@ check_eq 1_u64;
 push "balanceOf";
 hold_string_from_test_stack;
 push "address";
-hold_list_values_from_test_stack; 
+hold_list_values_from_test_stack;
 push 1010101_u160;
-hold_list_values_from_test_stack; 
-encode_call_data; 
+hold_list_values_from_test_stack;
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -129,12 +129,12 @@ check_eq 9900_u256;
 
 
 push "balanceOf";
-hold_string_from_test_stack; 
+hold_string_from_test_stack;
 push "address";
-hold_list_values_from_test_stack; 
+hold_list_values_from_test_stack;
 push 2020202_u160;
 hold_list_values_from_test_stack;
-encode_call_data; 
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -154,13 +154,13 @@ check_eq 100_u256;
 
 push "approve";
 hold_string_from_test_stack;
-push "address"; 
-push "uint256"; 
-hold_list_values_from_test_stack; 
+push "address";
+push "uint256";
+hold_list_values_from_test_stack;
 push 3030303_u160;
 push 200_u256;
 hold_list_values_from_test_stack;
-encode_call_data; 
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -191,7 +191,7 @@ push 1010101_u160;
 push 2020202_u160;
 push 200_u256;
 hold_list_values_from_test_stack;
-encode_call_data; 
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -219,7 +219,7 @@ push "address";
 hold_list_values_from_test_stack;
 push 1010101_u160;
 hold_list_values_from_test_stack;
-encode_call_data; 
+encode_call_data;
 return_value;
 mock CallData;
 
@@ -244,7 +244,7 @@ push "address";
 hold_list_values_from_test_stack;
 push 2020202_u160;
 hold_list_values_from_test_stack;
-encode_call_data; 
+encode_call_data;
 return_value;
 mock CallData;
 


### PR DESCRIPTION
End of line spaces look ugly in `git diff`. Also, they sometimes generate spurious diffs (e.g. change a line, then change it back, and there may be a diff because the end of line space is no longer there).